### PR TITLE
Handle invalid X-Robots-Tag header values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage/
+lib-es5/
 node_modules/
 .nyc_output/
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - 6
   - 8
+  - 10
+  - node
 script: npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
-  - 6
   - 8
+  - 10
+  - 12
+  - node
 script: npm run ci

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note: this library is not responsible for parsing any HTML.
 
 ## Installation
 
-[Node.js](http://nodejs.org/) `>= 6` is required. To install, type this at the command line:
+[Node.js](http://nodejs.org/) `>= 8` is required. To install, type this at the command line:
 ```shell
 npm install robot-directives
 ```
@@ -118,7 +118,7 @@ The HTTP user-agent to use when retrieving instructions via `is()` and `isNot()`
 
 
 [npm-image]: https://img.shields.io/npm/v/robot-directives.svg
-[npm-url]: https://npmjs.org/package/robot-directives
+[npm-url]: https://npmjs.com/package/robot-directives
 [travis-image]: https://img.shields.io/travis/stevenvachon/robot-directives.svg
 [travis-url]: https://travis-ci.org/stevenvachon/robot-directives
 [coveralls-image]: https://img.shields.io/coveralls/stevenvachon/robot-directives.svg

--- a/lib/group.js
+++ b/lib/group.js
@@ -5,21 +5,19 @@ const removeNo = require("./removeNo");
 
 
 const blank = () =>
-{
-	return {
-		all: null,
-		archive: null,
-		cache: null,
-		follow: null,
-		imageindex: null,
-		index: null,
-		none: null,
-		odp: null,
-		snippet: null,
-		translate: null,
-		unavailable_after: null
-	};
-};
+({
+	all: null,
+	archive: null,
+	cache: null,
+	follow: null,
+	imageindex: null,
+	index: null,
+	none: null,
+	odp: null,
+	snippet: null,
+	translate: null,
+	unavailable_after: null
+});
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const deepFreeze = require("deep-freeze-node");
 const defaultOptions =
 {
 	allIsReadonly: true,
-	currentTime: function(){ return Date.now() },
+	currentTime: () => Date.now(),
 	restrictive: true,
 	userAgent: ""
 };
@@ -29,7 +29,7 @@ const is = (instance, directive, options, inverted, any) =>
 	else
 	{
 		// TODO :: use evaluate-value
-		options = Object.assign({}, instance.options, options);
+		options = { ...instance.options, ...options };
 
 		if (options.userAgent !== instance.options.userAgent)
 		{
@@ -85,7 +85,7 @@ class RobotDirectives
 		this.directives      = { robots: group.initial()        };
 		this.directives_flat = { robots: this.directives.robots };
 
-		this.options = Object.assign({}, defaultOptions, options);
+		this.options = { ...defaultOptions, ...options };
 
 		this.bot = parseBotAgent(this.options.userAgent);
 

--- a/lib/splitDirectives.js
+++ b/lib/splitDirectives.js
@@ -11,25 +11,27 @@ const splitDirectives = directives =>
 
 	directives = prefixPattern.exec(directives);
 
-	if (directives[1] !== undefined)
-	{
-		result.prefix = directives[1].toLowerCase();
-	}
-
-	if (directives[2] !== undefined)
-	{
-		if (result.prefix === "unavailable_after")
+	if (directives !== null) {
+		if (directives[1] !== undefined)
 		{
-			result.values = [ directives[2].toLowerCase() ];
+			result.prefix = directives[1].toLowerCase();
+		}
+
+		if (directives[2] !== undefined)
+		{
+			if (result.prefix === "unavailable_after")
+			{
+				result.values = [ directives[2].toLowerCase() ];
+			}
+			else
+			{
+				result.values = directives[2].toLowerCase().split(",");
+			}
 		}
 		else
 		{
-			result.values = directives[2].toLowerCase().split(",");
+			result.values = [];
 		}
-	}
-	else
-	{
-		result.values = [];
 	}
 
 	return result;

--- a/package.json
+++ b/package.json
@@ -1,32 +1,38 @@
 {
   "name": "robot-directives",
   "description": "Parse robot directives within HTML meta and/or HTTP headers.",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha",
   "license": "MIT",
-  "author": "Steven Vachon <contact@svachon.com> (https://www.svachon.com/)",
+  "author": "Steven Vachon <contact@svachon.com> (https://svachon.com)",
+  "repository": "github:stevenvachon/robot-directives",
   "main": "lib",
-  "repository": "stevenvachon/robot-directives",
+  "browser": "lib-es5",
   "dependencies": {
-    "deep-freeze-node": "^1.1.2",
-    "isbot": "^2.0.3",
-    "useragent": "^2.1.13"
+    "deep-freeze-node": "^1.1.3",
+    "isbot": "^2.2.1",
+    "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "coveralls": "^2.13.1",
-    "mocha": "^3.4.2",
-    "nyc": "^11.0.2"
+    "@babel/cli": "^7.4.3",
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.3",
+    "mocha": "^6.1.4",
+    "nyc": "^14.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "ci": "npm run test && nyc report --reporter=text-lcov | coveralls",
     "posttest": "nyc report --reporter=html",
-    "test": "nyc --reporter=text-summary mocha test.js --reporter=spec --check-leaks --bail"
+    "prepublishOnly": "npm test && babel lib/ --out-dir=lib-es5/ --presets=@babel/env --source-maps",
+    "test": "nyc --reporter=text-summary mocha test.js --check-leaks --bail"
   },
   "files": [
-    "lib"
+    "lib",
+    "lib-es5"
   ],
   "keywords": [
     "crawlers",

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
   "name": "robot-directives",
   "description": "Parse robot directives within HTML meta and/or HTTP headers.",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha",
   "license": "MIT",
   "author": "Steven Vachon <contact@svachon.com> (https://www.svachon.com/)",
   "main": "lib",
   "repository": "stevenvachon/robot-directives",
   "dependencies": {
-    "deep-freeze-node": "^1.1.2",
-    "isbot": "^2.0.3",
-    "useragent": "^2.1.13"
+    "deep-freeze-node": "^1.1.3",
+    "isbot": "^2.2.1",
+    "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "coveralls": "^2.13.1",
-    "mocha": "^3.4.2",
-    "nyc": "^11.0.2"
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.2",
+    "mocha": "^5.2.0",
+    "nyc": "^13.1.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "ci": "npm run test && nyc report --reporter=text-lcov | coveralls",
     "posttest": "nyc report --reporter=html",
-    "test": "nyc --reporter=text-summary mocha test.js --reporter=spec --check-leaks --bail"
+    "test": "nyc --reporter=text-summary mocha test --check-leaks --bail"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -1,32 +1,38 @@
 {
   "name": "robot-directives",
   "description": "Parse robot directives within HTML meta and/or HTTP headers.",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha",
   "license": "MIT",
-  "author": "Steven Vachon <contact@svachon.com> (https://www.svachon.com/)",
+  "author": "Steven Vachon <contact@svachon.com> (https://svachon.com)",
+  "repository": "github:stevenvachon/robot-directives",
   "main": "lib",
-  "repository": "stevenvachon/robot-directives",
+  "browser": "lib-es5",
   "dependencies": {
-    "deep-freeze-node": "^1.1.2",
-    "isbot": "^2.0.3",
-    "useragent": "^2.1.13"
+    "deep-freeze-node": "^1.1.3",
+    "isbot": "^2.2.1",
+    "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "coveralls": "^2.13.1",
-    "mocha": "^3.4.2",
-    "nyc": "^11.0.2"
+    "@babel/cli": "^7.4.3",
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "chai": "^4.2.0",
+    "coveralls": "^3.0.3",
+    "mocha": "^6.1.4",
+    "nyc": "^14.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "ci": "npm run test && nyc report --reporter=text-lcov | coveralls",
-    "posttest": "nyc report --reporter=html",
-    "test": "nyc --reporter=text-summary mocha test.js --reporter=spec --check-leaks --bail"
+    "posttest": "nyc report --reporter=text-summary --reporter=html",
+    "prepublishOnly": "npm test && babel lib/ --out-dir=lib-es5/ --presets=@babel/env --source-maps",
+    "test": "nyc --silent mocha test.js --check-leaks --bail"
   },
   "files": [
-    "lib"
+    "lib",
+    "lib-es5"
   ],
   "keywords": [
     "crawlers",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 "use strict";
+const {describe, it} = require("mocha");
 const {expect} = require("chai");
-const {it} = require("mocha");
 const removeNo = require("./lib/removeNo");
 const RobotDirectives = require("./lib");
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 "use strict";
+const {describe, it} = require("mocha");
 const {expect} = require("chai");
-const {it} = require("mocha");
 const removeNo = require("./lib/removeNo");
 const RobotDirectives = require("./lib");
 
@@ -47,7 +47,7 @@ const newInstance = ({bot, directives, method, options}) =>
 
 const tests = method =>
 {
-	it(`resolves to "all" by default`, function()
+	it(`resolves to "all" by default`, () =>
 	{
 		expect(newInstance({ method, options:  restrictive, directives:"" }).is("all")).to.be.true;
 		expect(newInstance({ method, options:unrestrictive, directives:"" }).is("all")).to.be.true;
@@ -56,9 +56,9 @@ const tests = method =>
 		expect(newInstance({ method, options:unrestrictive, directives:"" }).is("follow")).to.be.true;
 	});
 
-	["archive","cache"].forEach( function(directive)
+	["archive","cache"].forEach(directive =>
 	{
-		it(`supports "${directive}"`, function()
+		it(`supports "${directive}"`, () =>
 		{
 			const excluded = ["noarchive", "nocache"];
 			const included = ["archive", "cache"];
@@ -87,9 +87,9 @@ const tests = method =>
 		});
 	});
 
-	["follow","index"].forEach( function(directive)
+	["follow","index"].forEach(directive =>
 	{
-		it(`supports "${directive}"`, function()
+		it(`supports "${directive}"`, () =>
 		{
 			expect(newInstance({ method, options:  restrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
 			expect(newInstance({ method, options:unrestrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
@@ -118,9 +118,9 @@ const tests = method =>
 		});
 	});
 
-	["imageindex","odp","snippet","translate"].forEach( function(directive)
+	["imageindex","odp","snippet","translate"].forEach(directive =>
 	{
-		it(`supports "${directive}"`, function()
+		it(`supports "${directive}"`, () =>
 		{
 			expect(newInstance({ method, options:  restrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
 			expect(newInstance({ method, options:unrestrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
@@ -147,9 +147,9 @@ const tests = method =>
 		});
 	});
 
-	["noarchive","nocache"].forEach( function(directive)
+	["noarchive","nocache"].forEach(directive =>
 	{
-		it(`supports "${directive}"`, function()
+		it(`supports "${directive}"`, () =>
 		{
 			const excluded = ["noarchive", "nocache"];
 			const included = ["archive", "cache"];
@@ -168,7 +168,7 @@ const tests = method =>
 		});
 	});
 
-	it(`supports "nofollow"`, function()
+	it(`supports "nofollow"`, () =>
 	{
 		expect(newInstance({ method, options:  restrictive, directives:"nofollow" }).is("nofollow")).to.be.true;
 		expect(newInstance({ method, options:unrestrictive, directives:"nofollow" }).is("nofollow")).to.be.true;
@@ -184,7 +184,7 @@ const tests = method =>
 		expect(newInstance({ method, options:unrestrictive, directives:"none,nofollow" }).is(none)).to.be.true;
 	});
 
-	it(`supports "noindex"`, function()
+	it(`supports "noindex"`, () =>
 	{
 		expect(newInstance({ method, options:  restrictive, directives:"noindex" }).is(noindex)).to.be.true;
 		expect(newInstance({ method, options:unrestrictive, directives:"noindex" }).is(noindex)).to.be.true;
@@ -200,9 +200,9 @@ const tests = method =>
 		expect(newInstance({ method, options:unrestrictive, directives:"none,noindex" }).is(none)).to.be.true;
 	});
 
-	["noimageindex","noodp","nosnippet","notranslate"].forEach( function(directive)
+	["noimageindex","noodp","nosnippet","notranslate"].forEach(directive =>
 	{
-		it(`supports "${directive}"`, function()
+		it(`supports "${directive}"`, () =>
 		{
 			expect(newInstance({ method, options:  restrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
 			expect(newInstance({ method, options:unrestrictive, directives:`${directive}` }).is(`${directive}`)).to.be.true;
@@ -219,13 +219,13 @@ const tests = method =>
 		});
 	});
 
-	it(`supports "none"`, function()
+	it(`supports "none"`, () =>
 	{
 		// Other cases for this directive are in other tests
 		expect( newInstance({ method, directives:"none" }).is(none) ).to.be.true;
 	});
 
-	it(`supports "all"`, function()
+	it(`supports "all"`, () =>
 	{
 		expect( newInstance({ method, options:  restrictive, directives:"all" }).is(all) ).to.be.true;
 		expect( newInstance({ method, options:allIsWritable, directives:"all" }).is(all) ).to.be.true;
@@ -233,13 +233,13 @@ const tests = method =>
 		expect( newInstance({ method, options:allIsWritable, directives:"nofollow,noindex,all" }).is(all ) ).to.be.true;
 	});
 
-	it(`supports "unavailable_after"`, function()
+	it(`supports "unavailable_after"`, () =>
 	{
 		expect( newInstance({ method, directives:"unavailable_after: 1-Jan-2000 00:00:00 EST" }).is(noindex                          ) ).to.be.true;
 		expect( newInstance({ method, directives:"unavailable_after: 1-Jan-3000 00:00:00 EST" }).is(noindex, {currentTime:futureTime}) ).to.be.true;
 	});
 
-	it("supports specific bot agents", function()
+	it("supports specific bot agents", () =>
 	{
 		expect( newInstance({ method,                    bot:"googlebot", directives:"nofollow,noindex" }).is(none) ).to.be.false;
 		expect( newInstance({ method, options:googlebot, bot:"googlebot", directives:"nofollow,noindex" }).is(none) ).to.be.true;
@@ -249,7 +249,7 @@ const tests = method =>
 		expect( newInstance({ method, directives:"googlebot: unavailable_after: 1-Jan-2000 00:00:00 EST" }).is(noindex) ).to.be.false;
 	});
 
-	it("supports edge cases", function()
+	it("supports edge cases", () =>
 	{
 		expect( newInstance({ method, directives:"nofollow,noindex" }).is(none) ).to.be.true;
 		expect( newInstance({ method, directives:"noindex,nofollow" }).is(none) ).to.be.true;
@@ -264,13 +264,13 @@ const tests = method =>
 		expect( newInstance({ method, options:unrestrictive, directives:"none,index"                    }).is(index      ) ).to.be.true;
 	});
 
-	it("supports whitespace between directives", function()
+	it("supports whitespace between directives", () =>
 	{
 		expect( newInstance({ method, directives:"nofollow,noindex,none"      }).is(none) ).to.be.true;
 		expect( newInstance({ method, directives:" nofollow,  noindex ,none " }).is(none) ).to.be.true;
 	});
 
-	it("does not support unknown directives", function()
+	it("does not support unknown directives", () =>
 	{
 		expect( newInstance({ method,                        directives:"unknown123" }).is("unknown123") ).to.be.false;
 		expect( newInstance({ method, options:unrestrictive, directives:"unknown123" }).is("unknown123") ).to.be.false;
@@ -279,25 +279,25 @@ const tests = method =>
 
 
 
-describe("is() / isNot()", function()
+describe("is() / isNot()", () =>
 {
-	it(`resolves to "all" by default`, function()
+	it(`resolves to "all" by default`, () =>
 	{
 		expect( new RobotDirectives().is("all") ).to.be.true;
 	});
 
-	it("does not support unknown directives", function()
+	it("does not support unknown directives", () =>
 	{
 		expect( new RobotDirectives().is("unknown123") ).to.be.false;
 	});
 
 
 
-	describe("with meta()", function()
+	describe("with meta()", () =>
 	{
 		tests("meta");
 
-		it("can be called multiple times", function()
+		it("can be called multiple times", () =>
 		{
 			const instance = new RobotDirectives();
 			instance.meta("robots", "nofollow");
@@ -309,11 +309,11 @@ describe("is() / isNot()", function()
 
 
 
-	describe("with header()", function()
+	describe("with header()", () =>
 	{
 		tests("header");
 
-		it("can be called multiple times", function()
+		it("can be called multiple times", () =>
 		{
 			const instance = new RobotDirectives();
 			instance.header("nofollow");
@@ -325,9 +325,9 @@ describe("is() / isNot()", function()
 
 
 
-	describe("with meta() + header()", function()
+	describe("with meta() + header()", () =>
 	{
-		it(`resolves to "all" by default`, function()
+		it(`resolves to "all" by default`, () =>
 		{
 			const instance = new RobotDirectives();
 			instance.header("");
@@ -336,7 +336,7 @@ describe("is() / isNot()", function()
 			expect( instance.is("all") ).to.be.true;
 		});
 
-		it("does not support unknown directives", function()
+		it("does not support unknown directives", () =>
 		{
 			const instance = new RobotDirectives();
 			instance.header("unknown123");
@@ -345,7 +345,7 @@ describe("is() / isNot()", function()
 			expect( instance.is("unknown123") ).to.be.false;
 		});
 
-		it("works", function()
+		it("works", () =>
 		{
 			const instance = new RobotDirectives();
 			instance.header("nofollow");
@@ -361,9 +361,9 @@ describe("is() / isNot()", function()
 
 
 
-describe("oneIs()", function()
+describe("oneIs()", () =>
 {
-	it("works", function()
+	it("works", () =>
 	{
 		expect( new RobotDirectives().header("nofollow").oneIs(["follow","nofollow"]) ).to.be.true;
 		expect( new RobotDirectives().header("nofollow").oneIs(["nofollow","follow"]) ).to.be.true;
@@ -374,9 +374,9 @@ describe("oneIs()", function()
 
 
 
-describe("oneIsNot()", function()
+describe("oneIsNot()", () =>
 {
-	it("works", function()
+	it("works", () =>
 	{
 		expect( new RobotDirectives().header("nofollow").oneIsNot(["follow","nofollow"]) ).to.be.true;
 		expect( new RobotDirectives().header("nofollow").oneIsNot(["nofollow","follow"]) ).to.be.true;
@@ -387,9 +387,9 @@ describe("oneIsNot()", function()
 
 
 
-describe("isBot()", function()
+describe("isBot()", () =>
 {
-	it("works", function()
+	it("works", () =>
 	{
 		expect( RobotDirectives.isBot("googlebot") ).to.be.true;
 		expect( RobotDirectives.isBot("  googleBot ") ).to.be.true;
@@ -399,9 +399,9 @@ describe("isBot()", function()
 
 
 
-describe("behavior", function()
+describe("behavior", () =>
 {
-	it("accepts redundant directives", function()
+	it("accepts redundant directives", () =>
 	{
 		const instance = new RobotDirectives();
 		instance.header("nocache");


### PR DESCRIPTION
In cases where the `X-Robots-Tag` header value is invalid, the regular expression will return `null` which will break the line after when it is assumed that `result` is an array and an element is accessed by index.

This fix will make the code fallback to the default value of `result`.

Example of a failing case (found in the wild): `'noindex, nofollow\nnosnippet, noarchive'`